### PR TITLE
🧪 Add unit tests for Or::is_right

### DIFF
--- a/src/v1/core/mod.rs
+++ b/src/v1/core/mod.rs
@@ -3,3 +3,4 @@ pub mod iterate;
 pub mod tuple;
 pub mod utility;
 pub mod view_vec;
+pub mod or;

--- a/src/v1/core/or.rs
+++ b/src/v1/core/or.rs
@@ -202,3 +202,24 @@ impl<T: DerefMut> DerefMut for Or<T, T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_left() {
+        let left: Or<u32, f32> = Left(1);
+        let right: Or<u32, f32> = Right(1.0);
+        assert!(left.is_left());
+        assert!(!right.is_left());
+    }
+
+    #[test]
+    fn test_is_right() {
+        let left: Or<u32, f32> = Left(1);
+        let right: Or<u32, f32> = Right(1.0);
+        assert!(!left.is_right());
+        assert!(right.is_right());
+    }
+}


### PR DESCRIPTION
The `Or::is_right` function was previously untested. This PR adds unit tests for both `is_left` and `is_right` functions to ensure they correctly identify the variants of the `Or` enum. It also includes the `or` module in the crate's module tree to enable compilation and testing.

🎯 **What:** Added unit tests for `Or::is_left` and `Or::is_right`.
📊 **Coverage:** Tested both `Left` and `Right` variants for both functions.
✨ **Result:** Improved test coverage and reliability of the `Or` utility.

---
*PR created automatically by Jules for task [17666459729858515203](https://jules.google.com/task/17666459729858515203) started by @Magicolo*